### PR TITLE
Move checking cuda device check into function body.

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -87,7 +87,7 @@ def available_models() -> List[str]:
     return list(_MODELS.keys())
 
 
-def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, download_root: str = None):
+def load(name: str, device: Union[str, torch.device] = None, jit: bool = False, download_root: str = None):
     """Load a CLIP model
 
     Parameters
@@ -112,6 +112,8 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
     preprocess : Callable[[PIL.Image], torch.Tensor]
         A torchvision transform that converts a PIL image into a tensor that the returned model can take as its input
     """
+    if not device:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
     if name in _MODELS:
         model_path = _download(_MODELS[name], download_root or os.path.expanduser("~/.cache/clip"))
     elif os.path.isfile(name):


### PR DESCRIPTION
Putting it in the function parameter appears to execute the code at time
of import which can lead to torch.CUDA complaining about multithreading
issues.

Fixes:

```
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```

when serving a flask app with gunicorn that imports this library.

Test with:

Note: You'll need a GPU.

1. Clone https://github.com/kreativai/torch-gun.
2. Modify `requirements.in` to use this branch of CLIP:
   * git+git://github.com/kreativai/CLIP@fix-named-parameter-setting#egg=clip
3. Build with:

```
export ADC_KEY=$HOME/.config/gcloud/application_default_credentials.json

export IMAGE="torch-gun"

docker buildx build \
    --no-cache \
    --platform linux/amd64 \
    --secret id=adc_key,src=$ADC_KEY \
    -t $IMAGE \
    ./
```

4. `docker run -it -p 5050:5050 --gpus all torch-gun`
5. Run the `test_http.py` script with requests installed.

See that the request succeeds.

6. (Optional) See that the request by building without updating the CLIP requirement fails.